### PR TITLE
Fix: Make tree item title detection more robust

### DIFF
--- a/src/folder-note.ts
+++ b/src/folder-note.ts
@@ -277,9 +277,9 @@ export class FolderNote {
         var noteBase = this.noteBase;
         parentElem.querySelectorAll(fileSelector)
             .forEach(function (fileElem) {
-                var fileNodeTitle = fileElem.firstElementChild.textContent;
+                var fileNodeTitle = fileElem.querySelector(':scope > .nav-file-title-content')?.textContent;
                 // console.log('fileNoteTitle: ', fileNodeTitle);
-                if (hideSetting && (fileNodeTitle == noteBase)) {
+                if (hideSetting && fileNodeTitle && (fileNodeTitle === noteBase)) {
                     fileElem.addClass('is-folder-note');
                 }
                 else if (!isOutsideMethod) {


### PR DESCRIPTION
This avoids compatibility issues with other plugins (like Iconize or Iconic) that insert additional elements into the DOM.